### PR TITLE
support macOS

### DIFF
--- a/main.js
+++ b/main.js
@@ -6,7 +6,7 @@ const config = require('./config.json')
 
 const parseOption = (argv) => {
   if (argv === undefined) argv = process.argv
-  if (path.basename(argv[0]).startsWith('electron')) {
+  if (path.basename(argv[0]).toLowerCase().startsWith('electron')) {
     argv = argv.slice(2)
   } else {
     argv = argv.slice(1)


### PR DESCRIPTION
手元のMacで動かなかったので修正しました。
macOS Mojave (10.14.6) で動作確認をしました。

### デバッグ
`console.log(process.argv)` した結果が以下です。
```
> pp@1.0.0 start /path/to/pp
> electron .

[
  '/path/to/pp/node_modules/electron/dist/Electron.app/Contents/MacOS/Electron',
  '.'
]
```
Windowsの時と違い、 `electron` ではなく `Electron` のようでした。